### PR TITLE
Sbit 581 mejorar performance lpc

### DIFF
--- a/src/components/Banners/BannerTop.js
+++ b/src/components/Banners/BannerTop.js
@@ -1,26 +1,27 @@
 import React from "react"
 import PropTypes from "prop-types"
-import { getImage } from "gatsby-plugin-image"
-import { BgImage } from "gbimage-bridge"
+import { getImage, GatsbyImage } from "gatsby-plugin-image"
+
 import "./BannerTop.scss"
 
 const BannerTop = ({ banner }) => {
   const { image, imagePage, title, variant = "" } = banner
-
-  const imageBanner =
-    getImage(image?.localFile) || getImage(imagePage?.localFile)
+  const imageBanner = getImage(image?.localFile) || getImage(imagePage?.localFile)
 
   return (
     <div className={`BannerTop ${variant}`}>
-      <BgImage image={imageBanner} className="BannerTop__bgImage">
-        <div className="BannerTop__titleContainer">
-          <h1
-            className={`BannerTop__title ${variant && "background container"}`}
-          >
-            {title}
-          </h1>
-        </div>
-      </BgImage>
+      <h1 className={`BannerTop__title ${variant && "background container"}`}>
+        {title}
+      </h1>
+      {imageBanner && (
+        <GatsbyImage
+          image={imageBanner}
+          alt={title}
+          className="BannerTop__bgImage"
+          loading="eager"
+          fetchpriority="high"
+        />
+      )}
     </div>
   )
 }

--- a/src/components/Banners/BannerTop.scss
+++ b/src/components/Banners/BannerTop.scss
@@ -1,27 +1,27 @@
 @import "../../styles/global.scss";
 
 .BannerTop {
+  position: relative;
+
   &__bgImage {
     min-height: 40vh;
     width: 100%;
-    display: flex;
-    align-items: flex-end;
-  }
-
-  &__titleContainer {
-    position: absolute;
-    bottom: 0;
-    background-color: rgba(36, 39, 42, 0.4);
-    padding: 24px 8px;
-    width: 100%;
+    object-fit: cover;
   }
 
   &__title {
-    text-wrap: pretty;
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    padding: 24px 8px;
+    background-color: rgba(36, 39, 42, 0.4);
     color: $white;
-    font-weight: $max-bold;
     margin-bottom: 0;
     text-transform: uppercase;
+    z-index: 2;
+    font-family: "Plain", sans-serif;
+    font-weight: 900;
+    font-size: $large;
 
     &:not(.background) {
       text-transform: none;
@@ -29,10 +29,8 @@
     }
   }
 
-  &.background {
-    &__titleContainer {
-      padding: 24px 8px;
-    }
+  &.background &__title {
+    padding: 24px 8px;
   }
 }
 
@@ -42,18 +40,13 @@
       min-height: 55vh;
     }
 
-    &__titleContainer {
+    &__title {
       padding: 30px;
-    }
-
-    &__title:not(.background) {
       font-size: $extra-large;
     }
 
-    &.background {
-      &__titleContainer {
-        padding: 30px 0;
-      }
+    &.background &__title {
+      padding: 30px 0;
     }
   }
 }

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -20,14 +20,15 @@ const Layout = ({ children, options = {}, location }) => {
 
   useEffect(() => {
     const hash = location?.state?.component
-    const el = hash && document.getElementById(hash)
-    if (el) el.scrollIntoView({ behavior: "smooth" })
+    let el = hash && document.getElementById(hash)
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth" })
+    }
   }, [location?.state?.component])
 
   const userLanguage =
     typeof window !== "undefined" ? navigator.language : undefined
 
-  // ✅ Consulta directa al bloque `home.video-background`
   const { strapiEnglishHome } = useStaticQuery(graphql`
     query GetVideoBackgroundImage {
       strapiEnglishHome {
@@ -66,23 +67,6 @@ const Layout = ({ children, options = {}, location }) => {
     <ThemeProvider>
       <Helmet>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        {fullHeroUrl && (
-          <link
-            rel="preload"
-            as="image"
-            href={fullHeroUrl}
-            imagesrcset={fullHeroUrl}
-            imagesizes="100vw"
-            crossorigin="anonymous"
-          />
-        )}
-        <link
-          rel="preload"
-          href="/fonts/plain-bold-webfont.woff2"
-          as="font"
-          type="font/woff2"
-          crossOrigin="anonymous"
-        />
       </Helmet>
 
       {options.hasHeader && <Header />}

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,10 +1,12 @@
-import React, { lazy, Suspense } from "react"
+import React, { lazy, Suspense, useEffect } from "react"
 import Header from "./header"
 import ThemeProvider from "../context/themeContext"
 import Footer from "./Footer/Footer"
 import "./layout.scss"
 import PropTypes from "prop-types"
 import "./FontAwesomeOne/FontAwesomeOne"
+import { Helmet } from "react-helmet"
+import { useStaticQuery, graphql } from "gatsby"
 
 const BannerRedirect = lazy(() => import("./BannerRedirect/BannerRedirect"))
 
@@ -16,28 +18,84 @@ const Layout = ({ children, options = {}, location }) => {
 
   options = { ...defaultOptions, ...options }
 
-  React.useEffect(() => {
+  useEffect(() => {
     const hash = location?.state?.component
-    let el = hash && document.getElementById(hash)
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth" })
-    }
+    const el = hash && document.getElementById(hash)
+    if (el) el.scrollIntoView({ behavior: "smooth" })
   }, [location?.state?.component])
 
   const userLanguage =
     typeof window !== "undefined" ? navigator.language : undefined
 
+  // ✅ Consulta directa al bloque `home.video-background`
+  const { strapiEnglishHome } = useStaticQuery(graphql`
+    query GetVideoBackgroundImage {
+      strapiEnglishHome {
+        body {
+          strapi_component
+          backgroundImage {
+            url
+            alternativeText
+            localFile {
+              childImageSharp {
+                gatsbyImageData(
+                  layout: FULL_WIDTH
+                  placeholder: BLURRED
+                  formats: [WEBP, AUTO]
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+  `)
+
+  const videoBlock = strapiEnglishHome?.body?.find(
+    block => block.strapi_component === "home.video-background"
+  )
+
+  const heroUrl = videoBlock?.backgroundImage?.url
+  const fullHeroUrl = heroUrl?.startsWith("http")
+    ? heroUrl
+    : heroUrl
+    ? `https://strapi-s3-bitlogic.s3.sa-east-1.amazonaws.com${heroUrl}`
+    : null
+
   return (
     <ThemeProvider>
+      <Helmet>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        {fullHeroUrl && (
+          <link
+            rel="preload"
+            as="image"
+            href={fullHeroUrl}
+            imagesrcset={fullHeroUrl}
+            imagesizes="100vw"
+            crossorigin="anonymous"
+          />
+        )}
+        <link
+          rel="preload"
+          href="/fonts/plain-bold-webfont.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+      </Helmet>
+
       {options.hasHeader && <Header />}
+
       {userLanguage?.startsWith("es") && (
-        <Suspense fallback>
+        <Suspense fallback={null}>
           <BannerRedirect />
         </Suspense>
       )}
+
       <main>{children}</main>
+
       {options.hasFooter && <Footer />}
-      {/*© {new Date().getFullYear()}, Built with*/}
     </ThemeProvider>
   )
 }

--- a/src/components/videoBackground/VideoBackground.js
+++ b/src/components/videoBackground/VideoBackground.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react"
 import "./videoBackground.scss"
 import CustomLink from "../CustomLink/CustomLink"
 import PropTypes from "prop-types"
-import { GatsbyImage, getImage } from "gatsby-plugin-image" // ✅ CAMBIO: usamos GatsbyImage
+import { GatsbyImage, getImage } from "gatsby-plugin-image" 
 
 function getIOSVersion() {
   if (typeof window === "undefined" || typeof navigator === "undefined") return null
@@ -180,7 +180,6 @@ const VideoBackground = ({ data }) => {
     localStorage.setItem("videoPaused", isVideoPause)
   }, [isVideoPause])
 
-  // ✅ CAMBIO: usamos imagen optimizada con GatsbyImage como fondo principal
   const backgroundSharp =
     backgroundImage?.localFile && getImage(backgroundImage.localFile)
 
@@ -196,9 +195,8 @@ const VideoBackground = ({ data }) => {
   )
 
   return (
-    <div className="videoBackground-wrapper"> {/* ✅ CAMBIO: sin inline style de background */}
-      
-      {/* ✅ CAMBIO: render de fondo con GatsbyImage (mejor para LCP) */}
+    <div className="videoBackground-wrapper"> 
+     
       {backgroundSharp && (
         <GatsbyImage
           image={backgroundSharp}

--- a/src/components/videoBackground/VideoBackground.js
+++ b/src/components/videoBackground/VideoBackground.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react"
 import "./videoBackground.scss"
 import CustomLink from "../CustomLink/CustomLink"
 import PropTypes from "prop-types"
-import { GatsbyImage, getImage } from "gatsby-plugin-image"
+import { GatsbyImage, getImage } from "gatsby-plugin-image" 
 
 function getIOSVersion() {
   if (typeof window === "undefined" || typeof navigator === "undefined") return null
@@ -43,7 +43,20 @@ function getVideoContent(
   const codeIndex = code.indexOf("?")
   if (codeIndex !== -1) code = code.substring(0, codeIndex)
 
-  if (!isIOSPriorTo("17.4")) {
+  const isMobile =
+    typeof window !== "undefined" && window.innerWidth <= 768
+  const isOldIOS = isIOSPriorTo("17.4")
+  if (isOldIOS && posterSharp) {
+    return (
+      <GatsbyImage
+        className="video-poster"
+        image={posterSharp}
+        alt={posterData.alternativeText || "Video poster"}
+        loading="eager"
+      />
+    )
+  }
+  if (!isMobile && !isOldIOS) {
     if (video?.url) {
       return (
         <video
@@ -55,7 +68,7 @@ function getVideoContent(
           controls={false}
           autoPlay={isIntersecting}
           poster={posterUrl}
-          preload="auto"
+          preload="none"
           onClick={pausePlay}
           onKeyDown={handleKeyDown}
         >
@@ -88,6 +101,7 @@ function getVideoContent(
         className="video-poster"
         image={posterSharp}
         alt={posterData.alternativeText || "Video poster"}
+        loading="eager"
       />
     )
   }
@@ -162,22 +176,25 @@ const VideoBackground = ({ data }) => {
     poster
   )
 
+  const bgSharp = backgroundImage?.localFile && getImage(backgroundImage.localFile) 
+
   return (
-    <div
-      style={{
-        backgroundImage: backgroundImage
-          ? `url(${backgroundImage.url})`
-          : "",
-        backgroundRepeatY: "no-repeat",
-        backgroundPosition: "center",
-      }}
-    >
+    <div className="videoBackground-wrapper"> 
+      {bgSharp && (
+        <GatsbyImage
+          image={bgSharp}
+          alt={description || "Video background"}
+          className="videoBackground-bg"
+          loading="eager"
+          fetchpriority="high"
+        />
+      )}
+
       <div className="container videoBackground-container">
         <section className="videoBackground">
-          {videoContent}
           {description && (
             <div className="videoBackground-card">
-              <h2>{description}</h2>
+              <h2 id="main-title" className="videoBackground-title">{description}</h2>
               {button && (
                 <CustomLink
                   content={button.content}
@@ -187,6 +204,7 @@ const VideoBackground = ({ data }) => {
               )}
             </div>
           )}
+          {videoContent}
         </section>
       </div>
     </div>
@@ -198,7 +216,7 @@ VideoBackground.propTypes = {
     video: PropTypes.shape({ url: PropTypes.string.isRequired, mime: PropTypes.string.isRequired }),
     videoUrl: PropTypes.string,
     description: PropTypes.string,
-    backgroundImage: PropTypes.shape({ url: PropTypes.string.isRequired }),
+    backgroundImage: PropTypes.shape({ url: PropTypes.string.isRequired, localFile: PropTypes.object }),
     image: PropTypes.shape({
       alternativeText: PropTypes.string,
       localFile: PropTypes.object,

--- a/src/components/videoBackground/VideoBackground.js
+++ b/src/components/videoBackground/VideoBackground.js
@@ -35,14 +35,12 @@ function getVideoContent(
   image,
   posterData
 ) {
-  const posterUrl =
-    posterData?.url && posterData.url.startsWith("http")
-      ? posterData.url
-      : posterData?.url
-      ? `https://strapi-s3-bitlogic.s3.sa-east-1.amazonaws.com${posterData.url}`
-      : null
-
+  
+  const posterUrl = posterData?.url?.startsWith("http")
+  ? getImage(posterData.url)
+  : getImage(`https://strapi-s3-bitlogic.s3.sa-east-1.amazonaws.com${posterData?.url}`)
   const posterSharp = posterData?.localFile && getImage(posterData.localFile)
+
 
   const url = videoUrl?.replace("watch?v=", "embed/")
   let code = url?.substring(url.lastIndexOf("/") + 1) || ""
@@ -51,7 +49,6 @@ function getVideoContent(
 
   const isOldIOS = isIOSPriorTo("17.4")
 
-  // ✅ CAMBIO: si es iOS viejo, mostramos directamente el poster
   if (isOldIOS && posterSharp) {
     return (
       <GatsbyImage

--- a/src/components/videoBackground/VideoBackground.js
+++ b/src/components/videoBackground/VideoBackground.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react"
 import "./videoBackground.scss"
 import CustomLink from "../CustomLink/CustomLink"
 import PropTypes from "prop-types"
-import { GatsbyImage, getImage } from "gatsby-plugin-image" 
+import { GatsbyImage, getImage } from "gatsby-plugin-image" // ✅ CAMBIO: usamos GatsbyImage
 
 function getIOSVersion() {
   if (typeof window === "undefined" || typeof navigator === "undefined") return null
@@ -35,7 +35,13 @@ function getVideoContent(
   image,
   posterData
 ) {
-  const posterUrl = posterData?.url
+  const posterUrl =
+    posterData?.url && posterData.url.startsWith("http")
+      ? posterData.url
+      : posterData?.url
+      ? `https://strapi-s3-bitlogic.s3.sa-east-1.amazonaws.com${posterData.url}`
+      : null
+
   const posterSharp = posterData?.localFile && getImage(posterData.localFile)
 
   const url = videoUrl?.replace("watch?v=", "embed/")
@@ -43,9 +49,9 @@ function getVideoContent(
   const codeIndex = code.indexOf("?")
   if (codeIndex !== -1) code = code.substring(0, codeIndex)
 
-  const isMobile =
-    typeof window !== "undefined" && window.innerWidth <= 768
   const isOldIOS = isIOSPriorTo("17.4")
+
+  // ✅ CAMBIO: si es iOS viejo, mostramos directamente el poster
   if (isOldIOS && posterSharp) {
     return (
       <GatsbyImage
@@ -53,46 +59,65 @@ function getVideoContent(
         image={posterSharp}
         alt={posterData.alternativeText || "Video poster"}
         loading="eager"
+        style={{ width: "100%", maxWidth: "100vw", height: "auto" }}
       />
     )
   }
-  if (!isMobile && !isOldIOS) {
-    if (video?.url) {
-      return (
-        <video
-          ref={videoRef}
-          muted
-          loop
-          playsInline
-          tabIndex={0}
-          controls={false}
-          autoPlay={isIntersecting}
-          poster={posterUrl}
-          preload="none"
-          onClick={pausePlay}
-          onKeyDown={handleKeyDown}
-        >
-          {isIntersecting && <source src={video.url} type={video.mime} />}
-        </video>
-      )
-    }
-    if (videoUrl) {
-      return (
-        <iframe
-          className="video"
-          loading="lazy"
-          type="text/html"
-          srcDoc={`<style>*{padding:0;margin:0;overflow:hidden}html,body{height:100%}img,span{position:absolute;width:100%;height:100%;object-fit:cover;top:0;bottom:0}span{height:1.5em;text-align:center;font:48px/1.5 sans-serif;color:white;margin:auto;text-shadow:0 0 0.5em black}</style><a href=${url}?rel=0><img src=https://img.youtube.com/vi/${code}/hqdefault.jpg alt='Video'><span>▶</span></a>`}
-          src={`${url}?rel=0`}
-          frameBorder="0"
-          allowFullScreen
-          title="benefits_video"
-          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-          webkitallowfullscreen
-          mozallowfullscreen
-        />
-      )
-    }
+
+  if (video?.url) {
+    return (
+      <video
+        ref={videoRef}
+        muted
+        loop
+        playsInline
+        tabIndex={0}
+        controls={false}
+        autoPlay={isIntersecting}
+        poster={posterUrl || undefined}
+        preload="auto"
+        onClick={pausePlay}
+        onKeyDown={handleKeyDown}
+        style={{
+          width: "100%",
+          maxWidth: "100vw",
+          height: "auto",
+          objectFit: "cover",
+          aspectRatio: "16/9",
+          display: "block",
+          borderRadius: "5px",
+        }}
+      >
+        {isIntersecting && <source src={video.url} type={video.mime} />}
+      </video>
+    )
+  }
+
+  if (videoUrl) {
+    return (
+      <iframe
+        className="video"
+        loading="lazy"
+        type="text/html"
+        srcDoc={`<style>*{padding:0;margin:0;overflow:hidden}html,body{height:100%}img,span{position:absolute;width:100%;height:100%;object-fit:cover;top:0;bottom:0}span{height:1.5em;text-align:center;font:48px/1.5 sans-serif;color:white;margin:auto;text-shadow:0 0 0.5em black}</style><a href=${url}?rel=0><img src=https://img.youtube.com/vi/${code}/hqdefault.jpg alt='Video'><span>▶</span></a>`}
+        src={`${url}?rel=0`}
+        frameBorder="0"
+        allowFullScreen
+        title="benefits_video"
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        webkitallowfullscreen
+        mozallowfullscreen
+        style={{
+          width: "100%",
+          maxWidth: "100vw",
+          height: "auto",
+          objectFit: "cover",
+          aspectRatio: "16/9",
+          display: "block",
+          borderRadius: "5px",
+        }}
+      />
+    )
   }
 
   if (posterSharp) {
@@ -102,11 +127,12 @@ function getVideoContent(
         image={posterSharp}
         alt={posterData.alternativeText || "Video poster"}
         loading="eager"
+        style={{ width: "100%", maxWidth: "100vw", height: "auto" }}
       />
     )
   }
 
-  return <div><br /></div>
+  return null
 }
 
 const VideoBackground = ({ data }) => {
@@ -125,8 +151,8 @@ const VideoBackground = ({ data }) => {
   const videoRef = useRef(null)
 
   const pausePlay = () => {
-    if (isVideoPause) videoRef.current.play()
-    else videoRef.current.pause()
+    if (isVideoPause) videoRef.current?.play()
+    else videoRef.current?.pause()
     setIsVideoPause(prev => !prev)
   }
 
@@ -139,6 +165,7 @@ const VideoBackground = ({ data }) => {
 
   useEffect(() => {
     const elem = videoRef.current
+    if (!elem) return
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
@@ -148,22 +175,17 @@ const VideoBackground = ({ data }) => {
       },
       { rootMargin: "0px 0px 200px 0px", threshold: 0.1 }
     )
-    if (elem) observer.observe(elem)
-    return () => elem && observer.unobserve(elem)
-  }, [])
-
-  useEffect(() => {
-    const stored =
-      typeof window !== "undefined" && localStorage.getItem("videoPaused")
-    if (stored === "true") {
-      videoRef.current.pause()
-      setIsVideoPause(true)
-    }
+    observer.observe(elem)
+    return () => observer.disconnect()
   }, [])
 
   useEffect(() => {
     localStorage.setItem("videoPaused", isVideoPause)
   }, [isVideoPause])
+
+  // ✅ CAMBIO: usamos imagen optimizada con GatsbyImage como fondo principal
+  const backgroundSharp =
+    backgroundImage?.localFile && getImage(backgroundImage.localFile)
 
   const videoContent = getVideoContent(
     video,
@@ -176,13 +198,13 @@ const VideoBackground = ({ data }) => {
     poster
   )
 
-  const bgSharp = backgroundImage?.localFile && getImage(backgroundImage.localFile) 
-
   return (
-    <div className="videoBackground-wrapper"> 
-      {bgSharp && (
+    <div className="videoBackground-wrapper"> {/* ✅ CAMBIO: sin inline style de background */}
+      
+      {/* ✅ CAMBIO: render de fondo con GatsbyImage (mejor para LCP) */}
+      {backgroundSharp && (
         <GatsbyImage
-          image={bgSharp}
+          image={backgroundSharp}
           alt={description || "Video background"}
           className="videoBackground-bg"
           loading="eager"
@@ -192,9 +214,10 @@ const VideoBackground = ({ data }) => {
 
       <div className="container videoBackground-container">
         <section className="videoBackground">
+          {videoContent}
           {description && (
             <div className="videoBackground-card">
-              <h2 id="main-title" className="videoBackground-title">{description}</h2>
+              <h2>{description}</h2>
               {button && (
                 <CustomLink
                   content={button.content}
@@ -204,7 +227,6 @@ const VideoBackground = ({ data }) => {
               )}
             </div>
           )}
-          {videoContent}
         </section>
       </div>
     </div>
@@ -213,10 +235,16 @@ const VideoBackground = ({ data }) => {
 
 VideoBackground.propTypes = {
   data: PropTypes.shape({
-    video: PropTypes.shape({ url: PropTypes.string.isRequired, mime: PropTypes.string.isRequired }),
+    video: PropTypes.shape({
+      url: PropTypes.string.isRequired,
+      mime: PropTypes.string.isRequired,
+    }),
     videoUrl: PropTypes.string,
     description: PropTypes.string,
-    backgroundImage: PropTypes.shape({ url: PropTypes.string.isRequired, localFile: PropTypes.object }),
+    backgroundImage: PropTypes.shape({
+      url: PropTypes.string.isRequired,
+      localFile: PropTypes.object,
+    }),
     image: PropTypes.shape({
       alternativeText: PropTypes.string,
       localFile: PropTypes.object,
@@ -224,12 +252,16 @@ VideoBackground.propTypes = {
     poster: PropTypes.shape({
       url: PropTypes.string.isRequired,
       alternativeText: PropTypes.string,
-      localFile: PropTypes.shape({ childImageSharp: PropTypes.object.isRequired }),
+      localFile: PropTypes.shape({
+        childImageSharp: PropTypes.object.isRequired,
+      }),
     }),
     button: PropTypes.shape({
       content: PropTypes.string.isRequired,
       url: PropTypes.string,
-      landing_page: PropTypes.shape({ slug: PropTypes.string.isRequired }),
+      landing_page: PropTypes.shape({
+        slug: PropTypes.string.isRequired,
+      }),
     }),
   }),
 }

--- a/src/components/videoBackground/videoBackground.scss
+++ b/src/components/videoBackground/videoBackground.scss
@@ -24,10 +24,9 @@
   &-card {
     width: 100%;
     min-height: 120px;
-    backdrop-filter: blur(14px);
+    background-color: rgba(232, 232, 232, 0.77);
     border-radius: 5px;
     color: $grey;
-    background: #e8e8e8c5;
     box-shadow: 0px 0px 3px #00000044;
     word-wrap: break-all;
     padding: 15px;
@@ -66,12 +65,21 @@
       position: absolute;
       bottom: 0;
       max-width: calc(700px - 60px);
-      backdrop-filter: blur(14px);
+      background-color: rgba(232, 232, 232, 0.77);
+
       border-radius: 5px;
-      background: #e8e8e8c5;
       box-shadow: 0px 0px 3px #00000044;
       margin: 2em;
       padding: 32px;
+    }
+  }
+}
+
+@media screen and (max-width: $breakpoint-md) {
+  .videoBackground {
+    &-card {
+      backdrop-filter: none;
+      box-shadow: none;
     }
   }
 }

--- a/src/components/videoBackground/videoBackground.scss
+++ b/src/components/videoBackground/videoBackground.scss
@@ -1,5 +1,20 @@
 @import "../../styles/global.scss";
 
+.videoBackground-wrapper {
+  position: relative; // ✅ CAMBIO: contenedor padre para fondo
+  overflow: hidden;
+
+  .videoBackground-bg { // ✅ CAMBIO: imagen de fondo (GatsbyImage)
+    position: absolute !important;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    object-fit: cover;
+  }
+}
+
 .videoBackground {
   max-width: 100%;
   height: fit-content;
@@ -28,8 +43,10 @@
     border-radius: 5px;
     color: $grey;
     box-shadow: 0px 0px 3px #00000044;
-    word-wrap: break-all;
+    word-wrap: break-word;
     padding: 15px;
+    z-index: 1; // ✅ CAMBIO: asegurar que quede sobre el fondo
+    position: relative;
   }
 
   .image {
@@ -66,7 +83,6 @@
       bottom: 0;
       max-width: calc(700px - 60px);
       background-color: rgba(232, 232, 232, 0.77);
-
       border-radius: 5px;
       box-shadow: 0px 0px 3px #00000044;
       margin: 2em;


### PR DESCRIPTION
Se reemplazaron fondos CSS por <GatsbyImage>, se agregó preload en Helmet, y se adaptó el render de video en iOS antiguos para mostrar solo el poster. También se ajustaron estilos para mejorar el rendimiento visual en mobile.