### PR TITLE
SBIT-604 botón de twitter enlace sin texto de anclaje 

### DIFF
--- a/src/components/FaIcon/FaIcon.js
+++ b/src/components/FaIcon/FaIcon.js
@@ -3,12 +3,10 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faEnvelope, faLocationDot } from "@fortawesome/free-solid-svg-icons"
 import {
   faLinkedin,
-  faTwitter,
-  faXTwitter, 
   faInstagram,
   faYoutube,
-  faSpotify
-  
+  faSpotify,
+  faXTwitter, 
 } from "@fortawesome/free-brands-svg-icons"
 import PropTypes from "prop-types"
 
@@ -16,7 +14,6 @@ const iconMap = {
   "fa-envelope": faEnvelope,
   "fa-location-dot": faLocationDot,
   "fa-linkedin": faLinkedin,
-  "fa-twitter": faTwitter,
   "fa-x-twitter": faXTwitter, 
   "fa-instagram": faInstagram,
   "fa-youtube": faYoutube,
@@ -24,7 +21,8 @@ const iconMap = {
 }
 
 const FaIcon = ({ type, code }) => {
-  const icon = iconMap[code]
+  const normalizedCode = code?.toLowerCase()
+  const icon = iconMap[normalizedCode]
 
   if (!icon) {
     console.warn(`Icono no encontrado: type=${type}, code=${code}`)
@@ -39,6 +37,4 @@ FaIcon.propTypes = {
   code: PropTypes.string.isRequired,
 }
 
-
 export default FaIcon
-

--- a/src/components/Footer/SocialLinks/socialLinks.js
+++ b/src/components/Footer/SocialLinks/socialLinks.js
@@ -8,20 +8,21 @@ import PropTypes from "prop-types"
 export default function SocialLinks({ image, socialMedia }) {
   const logo = getImage(image?.localFile?.childImageSharp?.gatsbyImageData)
 
-  const socialMediaItems = socialMedia?.map(item => {
-    return (
-      <a
-        key={item.id}
-        href={item.url}
-        target="_blank"
-        className={`btn-social m-2 btn-social-icon btn-${item.icon?.name}`}
-        rel="noreferrer"
-        aria-label={`Link externo a ${item?.name}`}
-      >
+  const socialMediaItems = socialMedia?.map(item => (
+    <a
+      key={item.id}
+      href={item.url}
+      target="_blank"
+      className={`btn-social m-2 btn-social-icon btn-${item.icon?.name}`}
+      rel="noreferrer"
+      aria-label={`External link to ${item?.name}`}
+    >
+      <>
         <FaIcon type={item.icon?.type} code={item.icon?.code} />
-      </a>
-    )
-  })
+        <span className="visually-hidden">Link to {item.name}</span>
+      </>
+    </a>
+  ))
 
   return (
     <div className="Footer__socialMedia d-flex flex-column">
@@ -33,10 +34,10 @@ export default function SocialLinks({ image, socialMedia }) {
 
       {logo && (
         <div className="Footer__socialMedia__Logo text-center">
-          <Link to="/">
+          <Link to="/en">
             <GatsbyImage
               image={logo}
-              alt={image?.alternativeText || "Logo Bitlogic"}
+              alt={image?.alternativeText || "Bitlogic Logo"}
             />
           </Link>
         </div>
@@ -60,6 +61,9 @@ SocialLinks.propTypes = {
       url: PropTypes.string,
       name: PropTypes.string,
       icon: PropTypes.shape({
+        name: PropTypes.string,
+        type: PropTypes.string,
+        code: PropTypes.string,
         url: PropTypes.string,
         alternativeText: PropTypes.string,
         localFile: PropTypes.shape({

--- a/src/components/Footer/SocialLinks/socialLinks.scss
+++ b/src/components/Footer/SocialLinks/socialLinks.scss
@@ -10,6 +10,9 @@
       color: $white;
       width: 21px;
       height: 21px;
+      display: inline-flex; 
+      align-items: center;
+      justify-content: center;
     }
   }
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -268,3 +268,15 @@ body {
     font-size: 3em;
   }
 }
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}


### PR DESCRIPTION
Se agregó un Link a {nombre de red} dentro de cada enlace social.
Se definió la clase .visually-hidden en global.scss para ocultar el texto visualmente pero mantenerlo accesible.
Se usó item.name para generar el texto dinámico (ej. “Link a Twitter”). Se hizo el cambio para todos los iconos, ya que si bien estaba reportdo solo para Twitter se presentaba el mismo error en los demas iconos.
El texto accesible ahora está presente en el DOM, no afecta el diseño y mejora la accesibilidad y el SEO. Se espera que el warning desaparezca en el próximo escaneo de Semrush.